### PR TITLE
Fixed Vercel deployment issue

### DIFF
--- a/packages/twentytwenty-theme/src/components/archive/archive.js
+++ b/packages/twentytwenty-theme/src/components/archive/archive.js
@@ -10,7 +10,7 @@ import tw from "tailwind.macro";
 import Link from "../link"
 import DeleteIcon from "../global/icons/DeleteIcon";
 import GetTaxonomyDescription from "../global/taxonomies/RecipeTaxonomies/GetTaxonomyDescription";
-import Author from "../global/author/author"
+import Author from "../global/author/Author"
 
 const Archive = ({state, showExcerpt, showMedia}) => {
     // Get the data of the current list.


### PR DESCRIPTION
You were trying to import component from author instead of the Author.

It worked fine because you were using the Windows OS and file names are the Windows file system isn’t case sensitive, so it treats these author and Author as the same files. But on the other hand, Vercel uses Linux, and the file system is case sensitive and author.js and Author.js are different files for it. So, it was trying to find author.js which wasn’t exist and as a result deployment was getting failed. 